### PR TITLE
Evaluation fixes

### DIFF
--- a/src/itr_evaluator.ml
+++ b/src/itr_evaluator.ml
@@ -955,7 +955,20 @@ and evaluate_expr (context : 'a context) (e : expr) : record_item =
     | Rec_value lhs, Rec_value rhs -> check_cmp lhs rhs op
     | _ -> Rec_value e)
   | Value (Funcall { func : value; args : record_item list })
-    when (func = Literal (String "LString.length")||func = Literal (String "String.length")||func = Literal (String "len")) && List.length args = 1 ->
+    when (func = Literal (String "len")) && List.length args = 1 ->
+    (match args with
+    | [ a ] ->
+      (match evaluate_record_item a with
+      | Rec_value (Value (Literal (String s))) ->
+        Rec_value (Value (Literal (Int (Z.of_int (CCString.length s)))))
+      | Rec_value (Value (Literal (Coll (_, l)))) ->
+        Rec_value (Value (Literal (Int (Z.of_int (CCList.length l)))))
+      | Rec_repeating_group { elements; _ } ->
+        Rec_value (Value (Literal (Int (Z.of_int (CCList.length elements)))))
+      | _ -> Rec_value e)
+    | _ -> Rec_value e)
+  | Value (Funcall { func : value; args : record_item list })
+    when (func = Literal (String "LString.length")||func = Literal (String "String.length")) && List.length args = 1 ->
     (match args with
     | [ a ] ->
       (match evaluate_record_item a with
@@ -964,7 +977,7 @@ and evaluate_expr (context : 'a context) (e : expr) : record_item =
       | _ -> Rec_value e)
     | _ -> Rec_value e)
   | Value (Funcall { func : value; args : record_item list })
-    when (func = Literal (String "List.length")||func = Literal (String "len")) && List.length args = 1 ->
+    when (func = Literal (String "List.length")) && List.length args = 1 ->
     (match args with
     | [ a ] ->
       (match evaluate_record_item a with

--- a/src/itr_evaluator.ml
+++ b/src/itr_evaluator.ml
@@ -1220,7 +1220,15 @@ and evaluate_expr (context : 'a context) (e : expr) : record_item =
     | Some context ->
       (match String_map.get v context.local_vars with
       | Some (Record_item ri) -> evaluate_record_item ri
-      | _ -> Rec_value e))
+      | Some (Msg { msg; _ }) ->
+        evaluate_record_item (context.get_field msg [])
+      | None -> 
+        (match context.implicit_message with 
+          | Some {msg; _} when String.equal v "msg_data" ->
+            evaluate_record_item (context.get_field msg [])
+          | _ -> Rec_value e
+        )
+        ))
   | Value (Literal (Coll (ct, l))) ->
     Rec_value (Value (Literal (Coll (ct, List.map evaluate_record_item l))))
   | Value (Literal (MapColl (d, vs))) ->

--- a/src/itr_evaluator.ml
+++ b/src/itr_evaluator.ml
@@ -1233,15 +1233,7 @@ and evaluate_expr (context : 'a context) (e : expr) : record_item =
     | Some context ->
       (match String_map.get v context.local_vars with
       | Some (Record_item ri) -> evaluate_record_item ri
-      | Some (Msg { msg; _ }) ->
-        evaluate_record_item (context.get_field msg [])
-      | None -> 
-        (match context.implicit_message with 
-          | Some {msg; _} when String.equal v "msg_data" ->
-            evaluate_record_item (context.get_field msg [])
-          | _ -> Rec_value e
-        )
-        ))
+      | _ -> Rec_value e))
   | Value (Literal (Coll (ct, l))) ->
     Rec_value (Value (Literal (Coll (ct, List.map evaluate_record_item l))))
   | Value (Literal (MapColl (d, vs))) ->


### PR DESCRIPTION
- Fixes a bug with length evaluation for repeating groups
- Evaluates `msg_data` variables using `implicit_message`

Both these fixes are needed for the first test case (`D_check_script.json`) from [this job](https://www.dev.imandracapital.com/ipl/jobs/3c39b386-afe1-4693-95c5-a433aa2d412e/fix-client?nodeLabel=state.OrdStatus).