### PR TITLE
Case expression and hof body simplification

### DIFF
--- a/src/itr_ast.ml
+++ b/src/itr_ast.ml
@@ -16,6 +16,7 @@ module Map_extra (M : CCMap.S) = struct
 end
 
 module String_map = Map_extra (CCMap.Make (CCString))
+module String_set = CCSet.Make (CCString)
 
 type field_path = (string * Z.t option) list
 


### PR DESCRIPTION
- Simplifies HOF bodies where possible, keeping tracking of bound lambda variables (allowing for proper consideration of ground terms in nested lambda expressions)
- Simplifies trivial case expressions (where a single branch might return true)