### PR TITLE
fix: opam package name

### DIFF
--- a/itr-ast.opam
+++ b/itr-ast.opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-name: "itr_ast"
+name: "itr-ast"
 version: "1.0"
 synopsis: "Imandra Test Runner AST"
 maintainer: "Ewen Maclean <ewen@aestheticintegration.com>"


### PR DESCRIPTION
So that the package name is the same as the file name as our utilities of `opam-nix` expects.