### PR TITLE
Fix Repeating Group evaluation of in

### DIFF
--- a/src/itr_evaluator.ml
+++ b/src/itr_evaluator.ml
@@ -336,10 +336,11 @@ and replace_record_item_in_expr (ri : expr) (e_check : record_item)
     | Rec_value lhs, Rec_value rhs -> Rec_value (Mul { lhs; op; rhs })
     | _ -> Rec_value (Mul { lhs; op; rhs }))
   | In { el : expr; set : value } ->
-    (match e_check, e_replace with
-    | Rec_value e_check, Rec_value e_replace ->
-      Rec_value (In { el = replace_expr_in_expr el e_check e_replace; set })
-    | _ -> Rec_value (In { el; set }))
+      (match (replace_record_item_in_expr el e_check e_replace) with
+      | Rec_value el ->
+        Rec_value (In { el; set })
+      | _ -> 
+        Rec_value (In {el; set}))
   | ri ->
     (match e_check, e_replace with
     | Rec_value e_check, Rec_value e_replace ->


### PR DESCRIPTION
Validation of repeating groups often includes clauses like `lambda_x1.PartyRole is in ['3', '122', '12']`

Currently, where `e_check` or `e_replace` are not `Rec_values` (e.g. are repeating group instances) the replacement fails to simplify (and thus properly evaluate to ground terms) `in` expressions.