### PR TITLE
Fix get_vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ _opam:
 
 .PHONY: dev-deps
 dev-deps: _opam
-	opam pin -y -n ocamlformat 0.20.1
+	opam pin -y -n ocamlformat 0.22.4
 	opam install -y ocamlformat merlin utop
 
 .PHONY: deps

--- a/src/itr_ast.ml
+++ b/src/itr_ast.ml
@@ -352,11 +352,14 @@ let rec fold f init e =
   | And { lhs; rhs }
   | Cmp { lhs; rhs; _ }
   | Add { lhs; rhs; _ }
-  | Mul { lhs; rhs; _ }
-  | Eq { lhs = Rec_value lhs; rhs = Rec_value rhs } ->
+  | Mul { lhs; rhs; _ } ->
     let init = fold f init lhs in
     let init = fold f init rhs in
     init
+  | Eq { lhs = Rec_value lhs; rhs = Rec_value rhs } ->
+    let lhs = Rec_value (fold f init lhs) in
+    let rhs = Rec_value (fold f init rhs) in
+    Eq { lhs; rhs }
   | In { el; _ } ->
     let init = fold f init el in
     init

--- a/test/dune
+++ b/test/dune
@@ -9,29 +9,22 @@
  (public_name itr_ast_test)
  (flags :standard -warn-error -A+8+39 -w -33-58)
  (modules itr_ast_test)
- (libraries
-  itr-ast))
+ (libraries itr-ast))
 
 (executable
  (name pp)
  (package itr-ast)
  (public_name pp)
  (flags :standard -warn-error -A+8+39 -w -33-58)
- (modules
-  pp)
-  (libraries itr-ast))
+ (modules pp)
+ (libraries itr-ast))
 
 (rule
  (alias runtest)
  (action
   (run %{exe:itr_ast_test.exe} all))
- (targets
-   simple_limit.out
-   test1.out
-   test2.out
-   test3.out
-   test4.out
-  )(deps
+ (targets simple_limit.out test1.out test2.out test3.out test4.out)
+ (deps
   (glob_files *.json)))
 
 (rule
@@ -39,21 +32,17 @@
  (action
   (diff simple_limit.expected simple_limit.out)))
 
-
 (rule
  (alias runtest)
  (action
   (diff test1.expected test1.out)))
-
 
 (rule
  (alias runtest)
  (action
   (diff test2.expected test2.out)))
 
-
 (rule
  (alias runtest)
  (action
   (diff test3.expected test3.out)))
-

--- a/test/itr_ast_test.ml
+++ b/test/itr_ast_test.ml
@@ -1,4 +1,3 @@
-
 let () = Itr_ast_pp.gen_pp "simple_limit.json"
 
 let () = Itr_ast_pp.gen_pp "test1.json"
@@ -8,5 +7,3 @@ let () = Itr_ast_pp.gen_pp "test2.json"
 let () = Itr_ast_pp.gen_pp "test3.json"
 
 let () = Itr_ast_pp.gen_pp "test4.json"
-
-

--- a/test/pp.ml
+++ b/test/pp.ml
@@ -1,3 +1,5 @@
 let () =
-  if Array.length Sys.argv < 2 then failwith "no argument specified" else
-  Itr_ast_pp.gen_pp Sys.argv.(1)
+  if Array.length Sys.argv < 2 then
+    failwith "no argument specified"
+  else
+    Itr_ast_pp.gen_pp Sys.argv.(1)


### PR DESCRIPTION
- Search deeper through values such as colls
- Return `ObjectProperty`s that are just properties on variables (e.g. `$var.foo.bar.baz`)