### PR TITLE
Repeating group evaluation fixes

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -3,6 +3,8 @@
  (public_name itr-ast)
  (wrapped false)
  (flags :standard -warn-error -A+8+39 -w -33-58)
+ (preprocess
+  (pps ppx_deriving.std))
  (libraries
   containers
   decoders

--- a/src/itr_ast.ml
+++ b/src/itr_ast.ml
@@ -18,7 +18,7 @@ end
 module String_map = Map_extra (CCMap.Make (CCString))
 module String_set = CCSet.Make (CCString)
 
-type field_path = (string * Z.t option) list
+type field_path = (string * Z.t option) list [@@deriving eq]
 
 module Field_path_set = CCSet.Make (struct
   type t = field_path
@@ -33,6 +33,7 @@ module Message_value = struct
     var: string option;
     field_path: field_path;
   }
+  [@@deriving eq]
 
   let mk ~var field_path = { var; field_path }
 
@@ -83,19 +84,22 @@ type hof_type =
   | Find
   | For_all2
   | Map2
+[@@deriving eq]
 
 type coll_type =
   | Set
   | List
   | Tuple
+[@@deriving eq]
 
 type datetime =
   | UTCTimestamp of T.t
   | UTCTimeOnly of T.t
   | UTCDateOnly of T.t
   | LocalMktDate of T.t
-  | MonthYear of T.t * TE.week option
+  | MonthYear of T.t * (TE.week[@equal fun a b -> a = b]) option
   | Duration of T.Span.t
+[@@deriving eq]
 
 type literal =
   | Bool of bool
@@ -187,6 +191,7 @@ and record_item =
       num_in_group_field: string;
       elements: record list;
     }
+[@@deriving eq]
 
 let rec expr_eq e1 e2 =
   match e1, e2 with

--- a/src/itr_evaluator.ml
+++ b/src/itr_evaluator.ml
@@ -983,7 +983,7 @@ and evaluate_expr (context : 'a context) (e : expr) : record_item =
   | Eq { lhs : record_item; rhs : record_item } ->
     let lhs = evaluate_record_item lhs in
     let rhs = evaluate_record_item rhs in
-    if lhs = rhs then
+    if Itr_ast.equal_record_item lhs rhs then
       e_true
     else if
       (* only evaluate equality to false if the terms have no variables *)


### PR DESCRIPTION
Use a weaker (derived) equivalence when evaluating `Eq`, often needed to compare two concrete repeating groups