### PR TITLE
Literal collection <-> Repeating group equivalence

### DIFF
--- a/src/itr_ast.ml
+++ b/src/itr_ast.ml
@@ -193,6 +193,17 @@ and record_item =
     }
 [@@deriving eq]
 
+let equal_record_item lhs rhs =
+  match lhs, rhs with
+  | ( Rec_repeating_group { elements; _ },
+      Rec_value (Value (Literal (Coll (List, coll_elements)))) )
+  | ( Rec_value (Value (Literal (Coll (List, coll_elements)))),
+      Rec_repeating_group { elements; _ } ) ->
+    CCList.equal equal_record_item
+      (CCList.map (fun r -> Rec_record r) elements)
+      coll_elements
+  | lhs, rhs -> equal_record_item lhs rhs
+
 let rec expr_eq e1 e2 =
   match e1, e2 with
   | Value v1, Value v2 -> value_eq v1 v2


### PR DESCRIPTION
Some higher-order functions (e.g. map, map2) transform repeating groups to literal collections under evaluation, so we should treat them as equivalent for the purpose of `Eq` evaluation

Thoughts on this would be welcome. An alternative might be attempting to preserve the repeating group structure under evaluation (e.g. [here](https://github.com/imandra-ai/itr-ast/blob/57d84758bd8e5b9b17e6981e0f280a77e0076e7a/src/itr_evaluator.ml#L1544-L1558)), but there may yet be other places where the two structures are treated interchangeably