### PR TITLE
fix: literal groundness checks

### DIFF
--- a/src/itr_evaluator.ml
+++ b/src/itr_evaluator.ml
@@ -683,6 +683,10 @@ let rec no_free_vars_expr (bound_lambda_vars : String_set.t) : expr -> bool =
     && CCList.for_all (fun (a, b) -> is_ground a && is_ground b) cases
   | Value (DataSetValue { default; constraints; _ }) ->
     is_ground default && CCList.for_all is_ground constraints
+  | Value (Literal (LiteralSome r)) -> is_ground r
+  | Value (Literal (Coll (_, l))) -> CCList.for_all is_ground l
+  | Value (Literal (MapColl (r, l))) ->
+    is_ground r && CCList.for_all (fun (l, r) -> is_ground l && is_ground r) l
   | Value (Literal _) -> true
   | Not e1 -> is_ground_expr e1
   | Or { lhs; rhs }

--- a/test/evaluator_test.expected
+++ b/test/evaluator_test.expected
@@ -10,3 +10,7 @@ Result evaluated and used when there's a fallback default:
   input: defaultIfNotSet(field_two,field_one)
   context: field_one -> "field_one", field_two -> "field_two"
   result: field_one 
+Result evaluated from equality to field path to: 
+  input: None = field_two
+  context: empty
+  result: None = field_two 

--- a/test/evaluator_test.ml
+++ b/test/evaluator_test.ml
@@ -95,3 +95,25 @@ let () =
     "@[<v 2>Result evaluated and used when there's a fallback default: @ \
      @[input: %a@]@ @[context: %a@]@ @[result: %a@] @]@."
     Itr_ast_pp.expr_pp item msg_pp msg Itr_ast_pp.record_item_pp result
+
+let () =
+  let field_path_one = [ "field_two", None ] in
+  let item =
+    Itr_ast.(
+      Eq
+        {
+          lhs =
+            Rec_value
+              (Value
+                 (Literal
+                    (LiteralNone)));
+          rhs =
+            Rec_value
+              (Value (MessageValue { var = None; field_path = field_path_one }));
+        })
+  in
+  let result = Itr_evaluator.evaluate_expr Itr_evaluator.empty_context item in
+  CCFormat.printf
+    "@[<v 2>Result evaluated from equality to field path to: @ @[input: %a@]@ \
+     @[context: empty@]@ @[result: %a@] @]@."
+    Itr_ast_pp.expr_pp item Itr_ast_pp.record_item_pp result


### PR DESCRIPTION
In particular to catch the case where we have `msg_0.field1 = Some (field0)` for the current message 