### PR TITLE
Description in instructions

### DIFF
--- a/src/itr_ast.ml
+++ b/src/itr_ast.ml
@@ -613,6 +613,12 @@ type instruction =
       variable: string option;
       tag: string;
       withs: record option;
+      description: string option;
+          (** Optionally provide a human-readable string of the expected send.  
+             If None, it will have no effect. If Some s, it will alter the display in the UI.
+
+             E.g. "Sending QuoteRequest: "
+          *)
     }
   | Receive of {
       variable: string option;
@@ -622,6 +628,8 @@ type instruction =
       description: string option;
           (** Optionally provide a human-readable string of the expected receive.  
              If None, it will have no effect. If Some s, it will alter the display in the UI.
+
+             E.g. "Expecting a NewOrderSingle with the following constraints:" 
           *)
     }
 
@@ -712,7 +720,8 @@ let set prop value = Set { prop; value }
 
 let not' e = Not e
 
-let send ?variable ~tag ?values () = Send { variable; withs = values; tag }
+let send ?variable ~tag ?values ?description () =
+  Send { variable; withs = values; tag; description }
 
 let expecting relevant_exprs common_exprs qe_modified_exprs nullable_exprs =
   { relevant_exprs; common_exprs; qe_modified_exprs; nullable_exprs }

--- a/src/itr_ast.ml
+++ b/src/itr_ast.ml
@@ -702,7 +702,7 @@ module Value = struct
       CCList.exists (exists_record_item f) (List.map (fun x -> x.value) fields)
     | Message { fields; _ } ->
       CCList.exists (exists_record_item f) (List.map (fun x -> x.value) fields)
-    | Send { variable = _; withs = record; tag = _ } ->
+    | Send { variable = _; withs = record; tag = _; description = _ } ->
       CCOption.exists (exists_record f) record
     | Receive { variable = _; where; expecting; _ } ->
       exists_expr f where
@@ -713,6 +713,7 @@ module Value = struct
                @ List.map fst e.nullable_exprs))
            expecting
     | Prompt _ -> false
+    | Comment _ -> false
 end
 
 let is_local_message_value = function

--- a/src/itr_ast.ml
+++ b/src/itr_ast.ml
@@ -632,6 +632,9 @@ type instruction =
              E.g. "Expecting a NewOrderSingle with the following constraints:" 
           *)
     }
+  | Comment of string
+      (** A comment which has no effect on the computation.
+          Only used to render user-friendly info in the front-end.  *)
 
 module Instructions_set = CCSet.Make (struct
   type t = instruction list

--- a/src/itr_ast.ml
+++ b/src/itr_ast.ml
@@ -619,6 +619,10 @@ type instruction =
       where: expr;
       expecting: expecting option;
       example: record;
+      description: string option;
+          (** Optionally provide a human-readable string of the expected receive.  
+             If None, it will have no effect. If Some s, it will alter the display in the UI.
+          *)
     }
 
 module Instructions_set = CCSet.Make (struct
@@ -713,5 +717,5 @@ let send ?variable ~tag ?values () = Send { variable; withs = values; tag }
 let expecting relevant_exprs common_exprs qe_modified_exprs nullable_exprs =
   { relevant_exprs; common_exprs; qe_modified_exprs; nullable_exprs }
 
-let receive ?variable ~where ?expecting ~example () =
-  Receive { variable; where; expecting; example }
+let receive ?variable ~where ?expecting ~example ?description () =
+  Receive { variable; where; expecting; example; description }

--- a/src/itr_ast_decoder.ml
+++ b/src/itr_ast_decoder.ml
@@ -486,4 +486,7 @@ let instruction_decoder () : I.instruction D.decoder =
       let* prop = field "variable" string in
       let+ value = field "call" (value_decoder ()) in
       I.Set { prop; value = Rec_value (Value value) }
+    | "Comment" ->
+       let+ comment = string in
+       I.Comment comment
     | _ -> fail "unrecognised instruction")

--- a/src/itr_ast_decoder.ml
+++ b/src/itr_ast_decoder.ml
@@ -473,8 +473,9 @@ let instruction_decoder () : I.instruction D.decoder =
       let* variable = field "variable" (nullable string) in
       let* where = field "where" (expr_decoder ()) in
       let* expecting = field "expecting" (nullable expecting_decoder) in
+      let* description = field_opt "description" string in
       let+ example = field "example" (record_decoder ()) in
-      I.Receive { variable; where; expecting; example }
+      I.Receive { variable; where; expecting; example; description }
     | "Prompt" ->
       let* prop = field "prop" string in
       let+ and_set = field "and_set" bool in

--- a/src/itr_ast_decoder.ml
+++ b/src/itr_ast_decoder.ml
@@ -468,7 +468,8 @@ let instruction_decoder () : I.instruction D.decoder =
           ]
       in
       let* withs = field "withs" (nullable (record_decoder ())) in
-      succeed (I.Send { variable; tag; withs })
+      let* description = field_opt "description" string in
+      succeed (I.Send { variable; tag; withs; description })
     | "Receive" ->
       let* variable = field "variable" (nullable string) in
       let* where = field "where" (expr_decoder ()) in

--- a/src/itr_ast_decoder.ml
+++ b/src/itr_ast_decoder.ml
@@ -487,6 +487,6 @@ let instruction_decoder () : I.instruction D.decoder =
       let+ value = field "call" (value_decoder ()) in
       I.Set { prop; value = Rec_value (Value value) }
     | "Comment" ->
-       let+ comment = string in
+       let+ comment = field "message" string in
        I.Comment comment
     | _ -> fail "unrecognised instruction")

--- a/src/itr_ast_json_pp.ml
+++ b/src/itr_ast_json_pp.ml
@@ -269,7 +269,7 @@ let rec instruction_to_json : instruction -> t = function
   | Prompt { prop; and_set } ->
     `Assoc
       [ "Prompt", `Assoc [ "prop", `String prop; "and_set", `Bool and_set ] ]
-  | Send { variable; tag; withs } ->
+  | Send { variable; tag; withs; description } ->
     `Assoc
       [
         ( "Send",
@@ -284,9 +284,13 @@ let rec instruction_to_json : instruction -> t = function
                 match withs with
                 | None -> `Null
                 | Some withs -> record_to_json withs );
+              ( "description",
+                match description with
+                | Some d -> `String d
+                | None -> `Null );
             ] );
       ]
-  | Receive { variable; where; expecting; example } ->
+  | Receive { variable; where; expecting; example; description } ->
     `Assoc
       [
         ( "Receive",
@@ -302,8 +306,14 @@ let rec instruction_to_json : instruction -> t = function
                 | None -> `Null
                 | Some e -> expecting_to_json e );
               "example", record_to_json example;
+              ( "description",
+                match description with
+                | Some d -> `String d
+                | None -> `Null );
             ] );
       ]
+  | Comment comment ->
+    `Assoc [ "Comment", `Assoc [ "message", `String comment ] ]
 
 and expecting_to_json (expecting : expecting) =
   `Assoc

--- a/src/itr_ast_pp.ml
+++ b/src/itr_ast_pp.ml
@@ -222,9 +222,9 @@ let rec instruction_pp (ppf : formatter) : instruction -> unit =
   | Message _ -> ()
   | Set { prop; value } ->
     fprintf ppf "set %s = %a" prop record_item_pp_parens value
-  | Send { variable; tag; withs; description } ->
-    fprintf ppf "@[<v>send %a(%s) %a : %a@]" pp_var_eq_opt variable tag
-      (CCFormat.some record_pp) withs CCFormat.(opt string) description
+  | Send { variable; tag; withs; _ } ->
+    fprintf ppf "@[<v>send %a(%s) %a@]" pp_var_eq_opt variable tag
+      (CCFormat.some record_pp) withs 
   | Prompt { prop; and_set } ->
     fprintf ppf "@[<v>prompt %s %s@]"
       (if and_set then

--- a/src/itr_ast_pp.ml
+++ b/src/itr_ast_pp.ml
@@ -222,9 +222,9 @@ let rec instruction_pp (ppf : formatter) : instruction -> unit =
   | Message _ -> ()
   | Set { prop; value } ->
     fprintf ppf "set %s = %a" prop record_item_pp_parens value
-  | Send { variable; tag; withs } ->
-    fprintf ppf "@[<v>send %a(%s) %a@]" pp_var_eq_opt variable tag
-      (CCFormat.some record_pp) withs
+  | Send { variable; tag; withs; description } ->
+    fprintf ppf "@[<v>send %a(%s) %a : %a@]" pp_var_eq_opt variable tag
+      (CCFormat.some record_pp) withs CCFormat.(opt string) description
   | Prompt { prop; and_set } ->
     fprintf ppf "@[<v>prompt %s %s@]"
       (if and_set then
@@ -245,6 +245,8 @@ let rec instruction_pp (ppf : formatter) : instruction -> unit =
       where
       (pp_expecting_opt expecting_pp)
       expecting
+  | Comment comment ->
+     fprintf ppf "@[<v 2>comment %s@]" comment
 
 and expecting_pp fmt (expecting : expecting) =
   let open CCFormat in


### PR DESCRIPTION
Related to imandra-ai/imandra-test-runner#305. 

Add the ability to manually add some text description to the `instruction` AST node. If present, it will alter the message displayed in the UI. Otherwise, display a default. 