### PR TITLE
chore: do not fix evaluate internally - fix evaluate on test

### DIFF
--- a/src/itr_ast_decoder.ml
+++ b/src/itr_ast_decoder.ml
@@ -487,6 +487,6 @@ let instruction_decoder () : I.instruction D.decoder =
       let+ value = field "call" (value_decoder ()) in
       I.Set { prop; value = Rec_value (Value value) }
     | "Comment" ->
-       let+ comment = field "message" string in
-       I.Comment comment
+      let+ comment = field "message" string in
+      I.Comment comment
     | _ -> fail "unrecognised instruction")

--- a/src/itr_ast_pp.ml
+++ b/src/itr_ast_pp.ml
@@ -224,7 +224,7 @@ let rec instruction_pp (ppf : formatter) : instruction -> unit =
     fprintf ppf "set %s = %a" prop record_item_pp_parens value
   | Send { variable; tag; withs; _ } ->
     fprintf ppf "@[<v>send %a(%s) %a@]" pp_var_eq_opt variable tag
-      (CCFormat.some record_pp) withs 
+      (CCFormat.some record_pp) withs
   | Prompt { prop; and_set } ->
     fprintf ppf "@[<v>prompt %s %s@]"
       (if and_set then
@@ -245,8 +245,7 @@ let rec instruction_pp (ppf : formatter) : instruction -> unit =
       where
       (pp_expecting_opt expecting_pp)
       expecting
-  | Comment comment ->
-     fprintf ppf "@[<v 2>comment %s@]" comment
+  | Comment comment -> fprintf ppf "@[<v 2>comment %s@]" comment
 
 and expecting_pp fmt (expecting : expecting) =
   let open CCFormat in

--- a/src/itr_evaluator.ml
+++ b/src/itr_evaluator.ml
@@ -852,7 +852,7 @@ let rec evaluate_record_item (context : 'a context) (e : record_item) :
 
 and evaluate_expr (context : 'a context) (e : expr) : record_item =
   let evaluate_expr = evaluate_expr context in
-  let evaluate_record_item = fix_evaluate_record_item context in
+  let evaluate_record_item = evaluate_record_item context in
   match e with
   | Not (Not expr) -> evaluate_expr expr
   | Not (Value (Funcall { func : value; args : record_item list }))

--- a/test/evaluator_test.ml
+++ b/test/evaluator_test.ml
@@ -185,7 +185,7 @@ let () =
     ]
   in
   let ctx = context msg local_vars in
-  let result = Itr_evaluator.evaluate_record_item ctx item in
+  let result = Itr_evaluator.fix_evaluate_record_item ctx item in
   CCFormat.printf
     "@[<v 2>Result evaluated with a variable with self reference: @ @[input: \
      %a@]@ @[local vars: %a@]@ @[result: %a@] @]@."


### PR DESCRIPTION
do not internally do fix-evaluate - just call it externally - otherwise it causes loops