### PR TITLE
fix: before ground check use fix eval

### DIFF
--- a/src/itr_evaluator.ml
+++ b/src/itr_evaluator.ml
@@ -914,7 +914,9 @@ and evaluate_expr (context : 'a context) (e : expr) : record_item =
         | Record_item (Rec_value (Value (Variable _)) as obj)
         | Record_item (Rec_value (Value (MessageValue _)) as obj) ->
           evaluate_expr (Value (ObjectProperty { obj; index; prop }))
-        | _ -> context.get_field event field_path)
+        | _ -> let ans = context.get_field event field_path in
+
+               ans)
       | _ -> Rec_value e))
   | Value
       (ObjectProperty { obj : record_item; index : Z.t option; prop : string })
@@ -1016,8 +1018,8 @@ and evaluate_expr (context : 'a context) (e : expr) : record_item =
     let rhs = a in
     evaluate_expr (Eq { lhs; rhs })
   | Eq { lhs : record_item; rhs : record_item } ->
-    let lhs = evaluate_record_item lhs in
-    let rhs = evaluate_record_item rhs in
+    let lhs = fix_evaluate_record_item context lhs in
+    let rhs = fix_evaluate_record_item context rhs in
     if Itr_ast.equal_record_item lhs rhs then
       e_true
     else if
@@ -1178,7 +1180,7 @@ and evaluate_expr (context : 'a context) (e : expr) : record_item =
       | Some Present ->
         Rec_value (Value (MessageValue { var = None; field_path }))
       | _ ->
-        let a = evaluate_expr a in
+        let a = fix_evaluate_record_item context (Rec_value a) in
         (match a with
         | Rec_value (Value (Literal LiteralNone)) -> evaluate_record_item d
         | _ ->
@@ -1196,7 +1198,7 @@ and evaluate_expr (context : 'a context) (e : expr) : record_item =
         Rec_value
           (Value (Funcall { func; args = CCList.map evaluate_record_item args })))
     | [ d; a ] ->
-      let a = evaluate_record_item a in
+      let a = fix_evaluate_record_item context a in
       (match a with
       | Rec_value (Value (Literal LiteralNone)) -> evaluate_record_item d
       | _ ->
@@ -1360,9 +1362,13 @@ and evaluate_expr (context : 'a context) (e : expr) : record_item =
       (match var, context.implicit_message with
       | Some x, _ ->
         (match String_map.get x context.local_vars with
-        | Some event -> context.get_field event field_path
+        | Some event ->
+          let ans = context.get_field event field_path in
+          ans
         | _ -> Rec_value e)
-      | None, Some event -> context.get_field (Msg event) field_path
+      | None, Some event ->
+        let ans = context.get_field (Msg event) field_path in
+        ans
       | None, None -> Rec_value e))
   | Value
       (Funcall
@@ -1708,8 +1714,8 @@ and evaluate_expr (context : 'a context) (e : expr) : record_item =
   | In { el : expr; set : value } ->
     (match evaluate_expr (Value set) with
     | Rec_value (Value (Literal (Coll (_, es)))) ->
-      let el = evaluate_expr el in
-      if List.mem el (List.map evaluate_record_item es) then
+      let el = fix_evaluate_record_item context (Rec_value el) in
+      if List.mem el (List.map (fix_evaluate_record_item context) es) then
         e_true
       else if is_ground el && List.for_all is_ground es then
         e_false
@@ -1777,7 +1783,7 @@ let get_all_subsets (l : 'a list) : 'a list list =
 
 let rec infer_field_presence (context : 'a context) (e : expr) : field_path list
     =
-  let evaluate_record_item = evaluate_record_item context in
+  let evaluate_record_item = fix_evaluate_record_item context in
   let evaluate_expr = evaluate_expr context in
   match e with
   | Cmp

--- a/test/evaluator_test.expected
+++ b/test/evaluator_test.expected
@@ -19,3 +19,7 @@ Result evaluated from equality to field path to:
   input: None = field_two
   context: empty
   result: None = field_two 
+Result evaluated from equality of FIX contextual terms: 
+  input: Some "1" = "1"
+  context: empty
+  result: true 

--- a/test/evaluator_test.ml
+++ b/test/evaluator_test.ml
@@ -209,3 +209,22 @@ let () =
     "@[<v 2>Result evaluated from equality to field path to: @ @[input: %a@]@ \
      @[context: empty@]@ @[result: %a@] @]@."
     Itr_ast_pp.expr_pp item Itr_ast_pp.record_item_pp result
+
+let () =
+  let item =
+    Itr_ast.(
+      Eq
+        {
+          lhs =
+            Rec_value
+              (Value
+                 (Literal
+                    (LiteralSome (Rec_value (Value (Literal (String "1")))))));
+          rhs = Rec_value (Value (Literal (String "1")));
+        })
+  in
+  let result = Itr_evaluator.evaluate_expr Itr_evaluator.empty_context item in
+  CCFormat.printf
+    "@[<v 2>Result evaluated from equality of FIX contextual terms: @ @[input: %a@]@ \
+     @[context: empty@]@ @[result: %a@] @]@."
+    Itr_ast_pp.expr_pp item Itr_ast_pp.record_item_pp result


### PR DESCRIPTION
The problem here is e.g. with an equality check between (Some "1") and ("1") - with fix evaluation these become optionally "flattened" in the evaluator (for FIX this makes sense) and works with the AST to IML runner decoder FIX that @sam-tombury made in the ipl repo. 

Now that we are less eagerly evaluation variables pointing to record structures, we no longer can internally use fix_evaluate_record_item in the main loop - however we can do when we have these `is_ground` checks - with equality we want to fix evaluate the arguments and if ground then return false or true - we can't do this if we don't fix evaluate as we are left with correct FIX -context equalities such as the one above which evaluates to false (incorrectly)